### PR TITLE
If text to be shown in bubble is empty, hide the bubble 

### DIFF
--- a/library/src/main/java/com/lb/recyclerview_fast_scroller/RecyclerViewFastScroller.java
+++ b/library/src/main/java/com/lb/recyclerview_fast_scroller/RecyclerViewFastScroller.java
@@ -137,8 +137,14 @@ public class RecyclerViewFastScroller extends LinearLayout {
             final int targetPos = getValueInRange(0, itemCount - 1, (int) (proportion * (float) itemCount));
             ((LinearLayoutManager) recyclerView.getLayoutManager()).scrollToPositionWithOffset(targetPos, 0);
             final String bubbleText = ((BubbleTextGetter) recyclerView.getAdapter()).getTextToShowInBubble(targetPos);
-            if (bubble != null)
+            if (bubble != null) {
                 bubble.setText(bubbleText);
+                if (TextUtils.isEmpty(bubbleText)) {
+                    hideBubble();
+                } else if (bubble.getVisibility() == View.INVISIBLE) {
+                    showBubble();
+                }
+            }
         }
     }
 


### PR DESCRIPTION
It looks out of place that we simply show the bubble without text when text to show is empty. With this change, the bubble will be hidden using methods already provided.